### PR TITLE
Remove empty figure when plotting

### DIFF
--- a/q1simulator/q1viewer.py
+++ b/q1simulator/q1viewer.py
@@ -82,7 +82,6 @@ def plot_q1asm_files(plot_defs,
         name = plot.sequencer_name if plot.sequencer_name else f'seq{i}'
         print(f'State {name}: {sim.get_sequencer_state(i)}')
 
-    pt.figure()
     sim.plot(t_min=t_min, t_max=t_max)
     pt.legend()
 


### PR DESCRIPTION
There is a now duplicate call to plt.figure() when plotting resulting in one empty plot being created.